### PR TITLE
Add support for target_commitish option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Options:
   --apiUrl [apiurl]               Use a custom API URL to connect to GitHub Enterprise instead of github.com.
                                   Defaults to "https://api.github.com"
                                   Ex: --apiUrl "https://myGHEserver/api/v3"
+
   --target_commitish [commitish]  Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA.
                                   Defaults to the default branch of the repository.
                                   Ex: --target_commitish "master"

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Options:
   --apiUrl [apiurl]               Use a custom API URL to connect to GitHub Enterprise instead of github.com.
                                   Defaults to "https://api.github.com"
                                   Ex: --apiUrl "https://myGHEserver/api/v3"
+  --target_commitish [commitish]  Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA.
+                                  Defaults to the default branch of the repository.
+                                  Ex: --target_commitish "master"
 ```
 
 ### API Usage
@@ -83,7 +86,8 @@ publishRelease({
   prerelease: false,
   reuseRelease: true,
   assets: ['/absolute/path/to/file'],
-  apiUrl: 'https://myGHEserver/api/v3'
+  apiUrl: 'https://myGHEserver/api/v3',
+  target_commitish: 'master'
 }, function (err, release) {
   // `release`: object returned from github about the newly created release
 })

--- a/bin/help.txt
+++ b/bin/help.txt
@@ -40,3 +40,7 @@ Options:
   --apiUrl [apiurl]               Use a custom API URL to connect to GitHub Enterprise instead of github.com.
                                   Defaults to "https://api.github.com"
                                   Ex: --apiUrl "https://myGHEserver/api/v3"
+
+  --target_commitish [commitish]  Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA.
+                                  Defaults to the default branch of the repository.
+                                  Ex: --target_commitish "master"

--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ PublishRelease.prototype.publish = function publish () {
           json: true,
           body: {
             tag_name: opts.tag,
+            target_commitish: opts.target_commitish,
             name: opts.name,
             body: opts.notes,
             draft: !!opts.draft,


### PR DESCRIPTION
Without this option, any release created will have it's release commit set to the latest commit of the default tracking branch. I need to be able to publish releases that point to specific branches/commits. Here is the relevant github api documentation https://developer.github.com/v3/repos/releases/#create-a-release.