### PR TITLE
Throw an error if assets can't be resolved. Fixes #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,17 @@ PublishRelease.prototype.publish = function publish () {
     return cb(new Error('missing required options: ' + missing.join(', ')))
   }
 
+  // check for existence of all assets
+  if (opts.assets && opts.assets.length > 0) {
+    try {
+      opts.assets.forEach(function (f) {
+        fs.accessSync(path.resolve(f))
+      })
+    } catch (err) {
+      cb(new Error('missing asset ' + err.path))
+    }
+  }
+
   async.auto({
     createRelease: function createRelease (callback) {
       var ghReleaseUri = util.format((opts.apiUrl || DEFAULT_API_ROOT) + '/repos/%s/%s/releases', opts.owner, opts.repo)


### PR DESCRIPTION
I think this the minimal change to fix #4. I tried to examine #11 and see if I could fix the conflicts, but so much of the changes were stylistic, so I just started from scratch.

I did some manual testing and it seems to be okay. One thing with the CLI is that it fails pretty late in the game (after setting up the request and authorizing), but thought refactoring that might be something that can be done later.