### PR TITLE
Fix for Issue #18 Error handling bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,19 +76,19 @@ PublishRelease.prototype.publish = function publish () {
             'Authorization': 'token ' + opts.token,
             'User-Agent': 'publish-release ' + pkg.version + ' (https://github.com/remixz/publish-release)'
           }
-        };
+        }
         request(reqDetails, function (err, res, body) {
           if (err) {
             // handle a real error, eg network fail
-            //will be handled by asyncAutoCallback
+            // will be handled by asyncAutoCallback
             return callback(err)
           }
           var errorStatus = res.statusCode >= 400 && res.statusCode < 600
-          if(errorStatus) {
+          if (errorStatus) {
             // handle an http error status
-            //will be handled by asyncAutoCallback
-            var e = new Error("Error status: "+ res.statusCode + "  response body:"+ JSON.stringify(body) + "\n request details:" + JSON.stringify(reqDetails, null, 2))
-            return callback(e);
+            // will be handled by asyncAutoCallback
+            var e = new Error('Error status: ' + res.statusCode + '  response body:' + JSON.stringify(body) + '\n request details:' + JSON.stringify(reqDetails, null, 2))
+            return callback(e)
           }
           self.emit('created-release')
           callback(null, body)
@@ -105,7 +105,7 @@ PublishRelease.prototype.publish = function publish () {
             'User-Agent': 'publish-release ' + pkg.version + ' (https://github.com/remixz/publish-release)'
           }
         }, function (err, res, body) {
-          if (err) return callback(err) //will be handled by asyncAutoCallback
+          if (err) return callback(err) // will be handled by asyncAutoCallback
 
           var statusOk = res.statusCode >= 200 && res.statusCode < 300
           var bodyOk = body[0] && body[0].tag_name === opts.tag
@@ -153,10 +153,10 @@ PublishRelease.prototype.publish = function publish () {
         })
 
         rd.on('error', function (err) {
-          return callback(err)  //will be handled by asyncAutoCallback
+          return callback(err)  // will be handled by asyncAutoCallback
         })
         us.on('error', function (err) {
-          return callback(err)  //will be handled by asyncAutoCallback
+          return callback(err)  // will be handled by asyncAutoCallback
         })
 
         us.on('end', function () {
@@ -166,19 +166,19 @@ PublishRelease.prototype.publish = function publish () {
 
         rd.pipe(prog).pipe(us)
       }, function (err) {
-        return callback(err); //will be handled by asyncAutoCallback
+        return callback(err) // will be handled by asyncAutoCallback
       })
     }]
   }, function asyncAutoCallback (err, obj) {
     if (err) {
-      //we are an EventEmitter so emit the 'error' event so the caller knows we failed.
-      self.emit('error', err);
+      // we are an EventEmitter so emit the 'error' event so the caller knows we failed.
+      self.emit('error', err)
       // just run the callback with no info. dont run cb(err) beacuse as an EventEmitter this creates a
       // throw Error('Uncaught, unspecified "error" event.')
       // and that error message isn't helpful to anyone
-      return cb();
+      return cb()
     }
-    //otherwise
+    // otherwise
     cb(null, obj.createRelease)
   })
 }


### PR DESCRIPTION
Hi @Aluxian,

I have fixed this bug in this project and in https://github.com/Aluxian/gulp-github-release and will create the Pull requests.

Basically this code as an EventEmitter should emit 'error' events. 
It also needed to handle the case where createRelease had a http error status code , ie >= 400, because although it handled a request err request does not think a 400 code is an error... it is correct because it is a valid http response :-).

However if the createRelease gets a 400 or above (eg 401 not authorised, due to bad token) then it needs to flag an error or else the downstream uploadAssets gets a bogus body object and fails. So that is what I've done

Cheers

Karl

