### PR TITLE
fix: callback for multiple duplicated assets

### DIFF
--- a/bin/help.txt
+++ b/bin/help.txt
@@ -34,7 +34,7 @@ Options:
                                   to create a new release if one already exists
                                   for the given tag.
 
-  --skipAssetCheck                Don't check if assets exist or not. False by default.
+  --skipAssetsCheck               Don't check if assets exist or not. False by default.
 
   --skipDuplicatedAssets          Pass this flag if you don't want the plugin to replace assets with the same
                                   name. False by default.

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ PublishRelease.prototype.publish = function publish () {
           }
         }, function (err, res, body) {
           if (err) return callback(err) // will be handled by asyncAutoCallback
-          
+
           var statusOk = res.statusCode >= 200 && res.statusCode < 300
           var bodyOk = body[0] && body[0].tag_name === opts.tag
           var canReuse = !opts.reuseDraftOnly || (body[0] && body[0].draft)

--- a/index.js
+++ b/index.js
@@ -177,6 +177,8 @@ PublishRelease.prototype.publish = function publish () {
                     callback()
                   }
                 })
+              } else {
+                callback()
               }
             } else {
               self.emit('uploaded-asset', fileName)

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ PublishRelease.prototype.publish = function publish () {
           }
         }, function (err, res, body) {
           if (err) return callback(err) // will be handled by asyncAutoCallback
-
+          
           var statusOk = res.statusCode >= 200 && res.statusCode < 300
           var bodyOk = body[0] && body[0].tag_name === opts.tag
           var canReuse = !opts.reuseDraftOnly || (body[0] && body[0].draft)
@@ -155,7 +155,7 @@ PublishRelease.prototype.publish = function publish () {
               self.emit('duplicated-asset', fileName)
 
               if (!opts.skipDuplicatedAssets) {
-                async.eachSeries(obj.createRelease.assets, function (el) {
+                async.eachSeries(obj.createRelease.assets, function (el, callback) {
                   if (fileName === el.name) {
                     const deleteAssetUri = obj.createRelease.url.split('/').slice(0, -1).join('/') + '/assets/' + el.id
 
@@ -171,7 +171,10 @@ PublishRelease.prototype.publish = function publish () {
 
                       self.emit('duplicated-asset-deleted', fileName)
                       requestUploadAsset()
+                      callback()
                     })
+                  } else {
+                    callback()
                   }
                 })
               }


### PR DESCRIPTION
- **fix: callback for multiple duplicated assets**
Prevent errors when try to delete multiple assets

- **docs(help): fix argument name**

- **fix: callback when skipDuplicatedAssets is true**
Prevent from freezing inside function when skipDuplciatedAssets is true and have multiple assets to delete
