### PR TITLE
Changed let to var

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ PublishRelease.prototype.publish = function publish () {
         }, function (err, res, body) {
           if (err) return callback(err) // will be handled by asyncAutoCallback
 
-          let bodyReturn = null
+          var bodyReturn = null
 
           async.eachSeries(body, function (el, callback) {
             if (el.tag_name === opts.tag) {


### PR DESCRIPTION
To support node versions less than 6

This single line breaks node 4 and 5 support. I do also like ES6 syntax, but without building the main file with babel it seems like a bad idea to bread support for it.

Detected this when builds in JsBarcode started to fail because of this https://travis-ci.org/lindell/JsBarcode/jobs/351896218