### PR TITLE
Add 'skipIfPublished' argument to CLI and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Options:
   --skipDuplicatedAssets          Pass this flag if you don't want the plugin to replace assets with the same
                                   name. False by default.
 
+  --skipIfPublished               Pass this flag if you don't want a new release to be created if a release with
+                                  the same tag has already been published (is not a draft). False by default.
+
   --editRelease                   Pass this flag if you want to edit release name, notes, type and target_commitish.
                                   It will need reuseRelease or/and reuseDraftOnly true to edit the release.
 
@@ -103,6 +106,7 @@ publishRelease({
   reuseDraftOnly: true,
   skipAssetsCheck: false,
   skipDuplicatedAssets: false,
+  skipIfPublished: false,
   editRelease: false,
   deleteEmptyTag: false,
   assets: ['/absolute/path/to/file'],

--- a/bin/help.txt
+++ b/bin/help.txt
@@ -39,6 +39,9 @@ Options:
   --skipDuplicatedAssets          Pass this flag if you don't want the plugin to replace assets with the same
                                   name. False by default.
 
+  --skipIfPublished               Pass this flag if you don't want a new release to be created if a release with
+                                  the same tag has already been published (is not a draft). False by default.
+
   --editRelease                   Pass this flag if you want to edit release name, notes, type and target_commitish.
                                   It will need reuseRelease or/and reuseDraftOnly true to edit the release.
 

--- a/bin/publish-release
+++ b/bin/publish-release
@@ -34,6 +34,7 @@ var opts = _.extend({
   prerelease: false,
   reuseRelease: false,
   skipAssetsCheck: false,
+  skipIfPublished: false,
   skipDuplicatedAssets: false,
   editRelease: false,
   deleteEmptyTag: false,

--- a/index.js
+++ b/index.js
@@ -123,14 +123,14 @@ PublishRelease.prototype.publish = function publish () {
           })
 
           var statusOk = res.statusCode >= 200 && res.statusCode < 300
-          var bodyOk = bodyReturn && bodyReturn.tag_name === opts.tag
+          var hasReleaseMatchingTag = bodyReturn && bodyReturn.tag_name === opts.tag
           var canReuse = !opts.reuseDraftOnly || (bodyReturn && bodyReturn.draft)
 
-          if (statusOk && bodyOk && canReuse) {
+          if (statusOk && hasReleaseMatchingTag && canReuse) {
             self.emit('reuse-release')
             bodyReturn.allowReuse = true // allow to editRelease
             callback(null, bodyReturn)
-          } else {
+          } else if (!hasReleaseMatchingTag || hasReleaseMatchingTag && !opts.skipIfPublished) {
             requestCreateRelease()
           }
         })


### PR DESCRIPTION
This change adds a new `skipIfPublished` argument to the CLI and API to
indicate that a new release should not be created if a non-draft release
with the same tag already exists.

Fixes #37.